### PR TITLE
Update _get_topic_partitions to fetch topic metadata if needed

### DIFF
--- a/src/logpipe/backend/kafka.py
+++ b/src/logpipe/backend/kafka.py
@@ -88,7 +88,10 @@ class Consumer(object):
         p = []
         partitions = self.client.partitions_for_topic(self.topic_name)
         if not partitions:
-            raise MissingTopicError('Could not find topic %s. Does it exist?' % self.topic_name)
+            self.client.topics()  # populates cache
+            partitions = self.client.partitions_for_topic(self.topic_name)
+            if not partitions:
+                raise MissingTopicError('Could not find topic %s. Does it exist?' % self.topic_name)
         for partition in partitions:
             tp = kafka.TopicPartition(self.topic_name, partition=partition)
             p.append(tp)


### PR DESCRIPTION
Now it will call kafka-python client._fetch_all_topic_metadata() if client.partitions_for_topic(self.topic_name) returns none.

This fixes an issue in which if the metadata had not been updated before it would not hit the cluster and say that the topic does not exist.

See https://github.com/thelabnyc/django-logpipe/issues/3 for more information and https://github.com/dpkp/kafka-python/pull/1781 for the fix on kafka-python.