### PR TITLE
Kafka cluster setup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,38 @@ If you're using AWS Kinesis instead of Kafka, it will look like this:
         # 'PRODUCER_ID': 'my-application-name',
     }
 
+If you're need to set any other attributes, you cas use "KAFKA_KWARGS"
+
+For example with Confluent Cloud will look like this:
+
+::
+
+    LOGPIPE = {
+        ...
+        # Optional Settings
+        'KAFKA_KWARGS': {
+            'security_protocol': 'SASL_SSL',
+            'sasl_mechanism': 'PLAIN',
+            'sasl_plain_username': '<api_key>',
+            'sasl_plain_password': '<api_secret>',
+        }
+    }
+
+or with OVHcloud will look like this:
+
+::
+
+    LOGPIPE = {
+        ...
+        # Optional Settings
+        'KAFKA_KWARGS': {
+            'security_protocol': 'SSL',
+            'ssl_cafile': '<ca.pem or ca.certificate.pem>',
+            'ssl_certfile': '<service.cert or access.certificate.pem>',
+            'ssl_keyfile': '<service.key or access.key>',
+        }
+    }
+
 Run migrations. This will create the model used to store Kafka log position offsets.::
 
     $ python manage.py migrate logpipe

--- a/src/logpipe/backend/kafka.py
+++ b/src/logpipe/backend/kafka.py
@@ -115,6 +115,7 @@ class Consumer(object):
             "enable_auto_commit": False,
             "consumer_timeout_ms": 1000,
         }
+        kwargs.update(settings.get("KAFKA_KWARGS", {}))
         kwargs.update(settings.get("KAFKA_CONSUMER_KWARGS", {}))
         kwargs.update(self.client_kwargs)
         kwargs.update(
@@ -145,9 +146,9 @@ class Producer(object):
         )
 
     def _get_client_config(self):
-        servers = settings.get("KAFKA_BOOTSTRAP_SERVERS")
-        retries = settings.get("KAFKA_MAX_SEND_RETRIES", 0)
-        return {
-            "bootstrap_servers": servers,
-            "retries": retries,
+        kwargs = {
+            "bootstrap_servers": settings.get("KAFKA_BOOTSTRAP_SERVERS"),
+            "retries": settings.get("KAFKA_MAX_SEND_RETRIES", 0),
         }
+        kwargs.update(settings.get("KAFKA_KWARGS", {}))
+        return kwargs


### PR DESCRIPTION
Added 'KAFKA_KWARGS' to set any other attributes in KafkaProducer and KafkaConsumer.

It will be useful for easily connect with large amount of clusters, Confluent Cloud and OVHcloud examples are provided in the README.rst

Thanks,
Christian
